### PR TITLE
request extended bot scopes

### DIFF
--- a/example/server.js
+++ b/example/server.js
@@ -30,8 +30,8 @@ passport.use(new SlackStrategy({
     clientID:     CLIENT_ID,
     clientSecret: CLIENT_SECRET,
     callbackURL:  CALLBACK_URL,
-    scope:        [],
-    user_scope:   ['users:read', 'users:read.email'],
+    scope:        ['users:read', 'users:read.email'],
+    user_scope:   [],
     passReqToCallback: true
   },
   (req, accessToken, refreshToken, profile, done) => {

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -122,8 +122,10 @@ util.inherits(Strategy, OAuth2Strategy);
  */
 Strategy.prototype.userProfile = function(accessToken, done) {
   this._oauth2.useAuthorizationHeaderforGET(true);
-  const access_token = accessToken.user.access_token;
+  const { access_token } = accessToken.user.access_token
+      ? accessToken.user : accessToken.bot;
   const provider = this.name;
+  // always get the requesting user's id (instead of the bot user)
   const { user_id: user } = accessToken.user;
   this._oauth2.get(`${this.profileUrl}?user=${user}`, access_token, function(err, body, res) {
     if (err) {
@@ -162,10 +164,11 @@ Strategy.prototype.authorizationParams = function(options) {
     const user_scope = options.user_scope.split(this._scopeSeparator);
     params.user_scope = [...new Set(user_scope)].join(this._scopeSeparator);
   } else {
-    const default_scope = this.scope.join(this._scopeSeparator);
-    const scope = (options.scope || default_scope).split(this._scopeSeparator);
-    params.scope = [...new Set(scope)].join(this._scopeSeparator);
-    params.user_scope = this.user_scope.join(this._scopeSeparator);
+    const requested_scopes = (options.scope || '').split(this._scopeSeparator).filter(s => s);
+    // merge profile with requested scopes
+    params.scope = [...new Set([...this.scope, ...requested_scopes])].join(this._scopeSeparator);
+    // request the extended scopes
+    options.scope = params.scope;
   }
   return params;
 };


### PR DESCRIPTION
augments the requested scopes with the ones defined in the strategy configuration in case of bot-tokens

e.g. 
if `scope` is set to `['users:read', 'users:read.email']` and the authorization request contains the `chat:write` scope, the resulting scopes will be `['users:read', 'users:read.email', 'chat:write']`.